### PR TITLE
support 'hours:minutes:seconds.milliseconds' notation

### DIFF
--- a/src/TimeConverter.php
+++ b/src/TimeConverter.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace M6Web\Component\Timecode;
+
+/**
+ * Time converter helper
+ */
+class TimeConverter
+{
+    /**
+     * Convert given milliseconds to its corresponding number of frames.
+     *
+     * @param int   $milliseconds
+     * @param float $framerate
+     *
+     * @return int
+     */
+    public static function millisecondsToFrames(int $milliseconds, float $framerate) : int
+    {
+        return floor($milliseconds / (1000 / $framerate));
+    }
+}

--- a/src/Timecode.php
+++ b/src/Timecode.php
@@ -73,10 +73,10 @@ class Timecode
         if (!empty($matches['hours']) && !empty($matches['minutes']) && !empty($matches['seconds']) && !empty($matches['frames'])) {
             // @codingStandardsIgnoreStart
             return new self(
-                (int) $matches['hours'],
-                (int) $matches['minutes'],
-                (int) $matches['seconds'],
-                (int) $matches['frames'],
+                $matches['hours'],
+                $matches['minutes'],
+                $matches['seconds'],
+                $matches['frames'],
                 $framerate
             );
             // @codingStandardsIgnoreEnd
@@ -88,10 +88,10 @@ class Timecode
         if (!empty($matches['hours']) && !empty($matches['minutes']) && !empty($matches['seconds']) && !empty($matches['ms'])) {
             // @codingStandardsIgnoreStart
             return new self(
-                (int) $matches['hours'],
-                (int) $matches['minutes'],
-                (int) $matches['seconds'],
-                TimeConverter::millisecondsToFrames((int) $matches['ms'], $framerate),
+                $matches['hours'],
+                $matches['minutes'],
+                $matches['seconds'],
+                TimeConverter::millisecondsToFrames($matches['ms'], $framerate),
                 $framerate
             );
             // @codingStandardsIgnoreEnd

--- a/tests/Units/TimeConverter.php
+++ b/tests/Units/TimeConverter.php
@@ -1,0 +1,87 @@
+<?php
+
+namespace M6Web\Component\Timecode\Tests\Units;
+
+use atoum;
+
+/**
+ * TimeConverter test class
+ */
+class TimeConverter extends atoum\test
+{
+    /**
+     * @dataProvider millisecondsToFramesDataProvider
+     */
+    public function testMillisecondsToFrames(
+        $milliseconds = null,
+        $framerate = null,
+        $expectedFrames = null
+    ) {
+        $this
+            ->given(
+                $testedClass = $this->testedClass->getClass()
+            )
+            ->when(
+                $actualFrames = $testedClass::millisecondsToFrames($milliseconds, $framerate)
+            )
+            ->then
+                ->integer($actualFrames)->isIdenticalTo($expectedFrames)
+        ;
+    }
+
+    protected function millisecondsToFramesDataProvider()
+    {
+        return [
+            '1, 25' => [
+                1,
+                (float) 25,
+                0,
+            ],
+            '10, 25' => [
+                10,
+                (float) 25,
+                0,
+            ],
+            '100, 25' => [
+                100,
+                (float) 25,
+                2,
+            ],
+            '1000, 25' => [
+                1000,
+                (float) 25,
+                25,
+            ],
+            '9999, 25' => [
+                9999,
+                (float) 25,
+                249,
+            ],
+            '1, 29.97' => [
+                1,
+                29.97,
+                0,
+            ],
+            '10, 29.97' => [
+                10,
+                29.97,
+                0,
+            ],
+            '100, 29.97' => [
+                100,
+                29.97,
+                2,
+            ],
+            '1000, 29.97' => [
+                1000,
+                29.97,
+                29,
+            ],
+            '9999, 29.97' => [
+                9999,
+                29.97,
+                299,
+            ],
+        ];
+    }
+}

--- a/tests/Units/Timecode.php
+++ b/tests/Units/Timecode.php
@@ -25,6 +25,21 @@ class Timecode extends atoum\test
             ->given(
                 $testedClass = $this->testedClass->getClass()
             )
+        ;
+
+        // Handle exceptions
+        if (is_null($expectedHours) || is_null($expectedMinutes) || is_null($expectedSeconds) || is_null($expectedFrames) || is_null($expectedFramerate)) {
+            $this->exception(function() use ($testedClass, $timecodeStr, $framerate) {
+                is_null($framerate) ? $testedClass::createFromString($timecodeStr) : $testedClass::createFromString($timecodeStr, $framerate);
+            })
+                ->isInstanceOf('InvalidArgumentException')
+                ->hasMessage('Unsupported string notation.')
+            ;
+
+            return;
+        }
+
+        $this
             ->when(
                 /** @var \M6Web\Component\Timecode\Timecode $timecode */
                 $timecode = is_null($framerate) ? $testedClass::createFromString($timecodeStr) : $testedClass::createFromString($timecodeStr, $framerate)
@@ -41,7 +56,16 @@ class Timecode extends atoum\test
     protected function createFromStringDataProvider()
     {
         return [
-            'default framerate' => [
+            'unsupported notation' => [
+                '12345.345.6543:12',
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+            ],
+            'hours:minutes:seconds:frames default framerate' => [
                 '09:02:00:03',
                 null,
                 9,
@@ -50,7 +74,7 @@ class Timecode extends atoum\test
                 3,
                 (float) 25,
             ],
-            'int framerate' => [
+            'hours:minutes:seconds:frames int framerate' => [
                 '99:59:59:59',
                 60,
                 99,
@@ -59,8 +83,35 @@ class Timecode extends atoum\test
                 59,
                 (float) 60,
             ],
-            'float framerate' => [
+            'hours:minutes:seconds:frames float framerate' => [
                 '99:59:59:28',
+                29.97,
+                99,
+                59,
+                59,
+                28,
+                (float) 29.97,
+            ],
+            'hours:minutes:seconds.milliseconds default framerate' => [
+                '09:02:00.120',
+                null,
+                9,
+                2,
+                0,
+                3,
+                (float) 25,
+            ],
+            'hours:minutes:seconds.milliseconds int framerate' => [
+                '99:59:59.999',
+                60,
+                99,
+                59,
+                59,
+                59,
+                (float) 60,
+            ],
+            'hours:minutes:seconds.milliseconds float framerate' => [
+                '99:59:59.940',
                 29.97,
                 99,
                 59,


### PR DESCRIPTION
## Why
`Timecode::createFromString('00:00:05:20')` <= frames notation (currently supported)
`Timecode::createFromString('00:00:05.880')` <= milliseconds notation (not currently supported, but will be, thanks to this PR)